### PR TITLE
Ignore messages for a different namespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var uid = require('uid2')(6);
+var uid2 = require('uid2');
 var redis = require('redis').createClient;
 var msgpack = require('msgpack-js');
 var Adapter = require('socket.io-adapter');
@@ -51,6 +51,7 @@ function adapter(uri, opts){
   if (!sub) sub = redis(port, host, {detect_buffers: true});
 
   // this server's key
+  var uid = uid2(6);
   var key = prefix + '#' + uid;
 
   /**
@@ -86,6 +87,7 @@ function adapter(uri, opts){
     var pieces = channel.split('#');
     if (uid == pieces.pop()) return debug('ignore same uid');
     var args = msgpack.decode(msg);
+    if (!args[0] || args[0].nsp != this.nsp.name) return debug('ignore different namespace')
     args.push(true);
     this.broadcast.apply(this, args);
   };

--- a/package.json
+++ b/package.json
@@ -2,11 +2,21 @@
   "name": "socket.io-redis",
   "version": "0.1.0",
   "description": "",
+  "scripts": {
+    "test": "mocha"
+  },
   "dependencies": {
     "debug": "0.7.4",
     "uid2": "0.0.3",
     "redis": "0.10.1",
     "msgpack-js": "0.3.0",
     "socket.io-adapter": "0.1.0"
+  },
+  "devDependencies": {
+    "socket.io": "1.0.0-pre",
+    "socket.io-client": "1.0.0-pre",
+    "mocha": "1.18.0",
+    "expect.js": "0.3.1",
+    "async": "0.2.10"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,128 @@
+var http = require('http').Server;
+var io = require('socket.io');
+var ioc = require('socket.io-client');
+var expect = require('expect.js');
+var async = require('async');
+var redis = require('redis');
+var redisAdapter = require('../');
+
+
+function client(srv, nsp, opts){
+  if ('object' == typeof nsp) {
+    opts = nsp;
+    nsp = null;
+  }
+  var addr = srv.address();
+  if (!addr) {
+    addr = srv.listen().address();
+  }
+  var url = 'ws://' + addr.address + ':' + addr.port + (nsp || '');
+  return ioc(url, opts);
+}
+
+describe('socket.io-redis', function(){
+  describe('broadcast', function(){
+    beforeEach(function(done){
+      this.redisClients = [];
+      var self = this;
+
+      async.times(2, function(n, next){
+        var pub = redis.createClient();
+        var sub = redis.createClient(null, null, {detect_buffers: true});
+        var srv = http();
+        var sio = io(srv, {adapter: redisAdapter({pubClient: pub, subClient: sub})});
+        self.redisClients.push(pub, sub);
+
+        srv.listen(function(){
+          ['/', '/nsp'].forEach(function(name){
+            sio.of(name).on('connection', function(socket){
+              socket.on('join', function(callback){
+                socket.join('room', callback);
+              });
+
+              socket.on('socket broadcast', function(data){
+                socket.broadcast.to('room').emit('broadcast', data);
+              });
+
+              socket.on('namespace broadcast', function(data){
+                sio.of('/nsp').in('room').emit('broadcast', data);
+              });
+            });
+          });
+
+          async.parallel([
+            function(callback){
+              async.times(2, function(n, next){
+                var socket = client(srv, '/nsp', {forceNew: true});
+                socket.on('connect', function(){
+                  socket.emit('join', function(){
+                    next(null, socket);
+                  });
+                });
+              }, callback);
+            },
+            function(callback){
+              // a socket of the same namespace but not joined in the room.
+              var socket = client(srv, '/nsp', {forceNew: true});
+              socket.on('connect', function(){
+                socket.on('broadcast', function(){
+                  throw new Error('Called unexpectedly: different room');
+                });
+                callback();
+              });
+            },
+            function(callback){
+              // a socket joined in a room but for a different namespace.
+              var socket = client(srv, {forceNew: true});
+              socket.on('connect', function(){
+                socket.on('broadcast', function(){
+                  throw new Error('Called unexpectedly: different namespace');
+                });
+                socket.emit('join', function(){
+                  callback();
+                });
+              });
+            }
+          ], function(err, results){
+            next(err, results[0]);
+          });
+        });
+      }, function(err, sockets){
+        self.sockets = sockets.reduce(function(a, b){ return a.concat(b); });
+        done(err);
+      });
+    });
+
+    afterEach(function(){
+      this.redisClients.forEach(function(client){
+        client.quit();
+      });
+    });
+
+    it('should broadcast from a socket', function(done){
+      async.each(this.sockets.slice(1), function(socket, next){
+        socket.on('broadcast', function(message){
+          expect(message).to.equal('hi');
+          next();
+        });
+      }, done);
+
+      var socket = this.sockets[0];
+      socket.on('broadcast', function(){
+        throw new Error('Called unexpectedly: same socket');
+      });
+      socket.emit('socket broadcast', 'hi');
+    });
+
+    it('should broadcast from a namespace', function(done){
+      async.each(this.sockets, function(socket, next){
+        socket.on('broadcast', function(message){
+          expect(message).to.equal('hi');
+          next();
+        });
+      }, done);
+
+      this.sockets[0].emit('namespace broadcast', 'hi');
+    });
+  });
+});


### PR DESCRIPTION
An adapter is created per namespace, thus messages for a different namespace should be ignored.
