### PR TITLE
Replace detect_buffers with return_buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ a connection string.
 var redis = require('redis').createClient;
 var adapter = require('socket.io-redis');
 var pub = redis(port, host, { auth_pass: "pwd" });
-var sub = redis(port, host, { detect_buffers: true, auth_pass: "pwd" });
+var sub = redis(port, host, { return_buffers: true, auth_pass: "pwd" });
 io.adapter(adapter({ pubClient: pub, subClient: sub }));
 ```
 
-Make sure the `detect_buffers` option is set to `true` for the sub client.
+Make sure the `return_buffers` option is set to `true` for the sub client.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function adapter(uri, opts){
 
   // init clients if needed
   if (!pub) pub = redis(port, host);
-  if (!sub) sub = redis(port, host, { detect_buffers: true });
+  if (!sub) sub = redis(port, host, { return_buffers: true });
 
   // this server's key
   var uid = uid2(6);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "async": "0.9.0",
     "debug": "0.7.4",
     "msgpack-js": "0.3.0",
-    "redis": "0.10.1",
+    "redis": "2.3.0",
     "socket.io-adapter": "automattic/socket.io-adapter#de5cba",
     "uid2": "0.0.3"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -65,7 +65,7 @@ describe('socket.io-redis', function(){
     var sio = io(srv);
     sio.adapter(adapter({
       pubClient: redis(),
-      subClient: redis(null, null, { detect_buffers: true })
+      subClient: redis(null, null, { return_buffers: true })
     }));
     srv.listen(function(err){
       if (err) throw err; // abort tests


### PR DESCRIPTION
You should use `return_buffers` instead of `detect_buffers` as `detect_buffers` is no longer work with pub/sub (since 2.0.0). Also `return_buffers` is not working in version 2.2.0-2.2.5 due to bug NodeRedis/node_redis#911, but it works in 2.3.0.