### PR TITLE
Allow configuring which redis database number is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ is located. For a list of options see below.
 
 The following options are allowed:
 
+- `databaseNumber`: the number of the redis database to connect to (`0`)
 - `key`: the name of the key to pub/sub events on as prefix (`socket.io`)
 - `host`: host to connect to redis on (`localhost`)
 - `port`: port to connect to redis on (`6379`)

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ function adapter(uri, opts){
   }
 
   // opts
+  var databaseNumber = opts.databaseNumber || 0;
   var host = opts.host || '127.0.0.1';
   var port = Number(opts.port || 6379);
   var pub = opts.pubClient;
@@ -51,6 +52,14 @@ function adapter(uri, opts){
   // init clients if needed
   if (!pub) pub = redis(port, host);
   if (!sub) sub = redis(port, host, { return_buffers: true });
+  if (0 !== databaseNumber) {
+    if (!opts.pubClient) {
+      pub.select(databaseNumber);
+    }
+    if (!opts.subClient) {
+      sub.select(databaseNumber);
+    }
+  }
 
   // this server's key
   var uid = uid2(6);


### PR DESCRIPTION
This allows the user to pass in a `databaseNumber` option to configure which database to connect to.

If there are any tests or documentation that need to be updated just let me know and I'll be happy to contribute.