### PR TITLE
Updated node-redis dependency to 2.4.2, which matches socket.io-emitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "async": "0.9.0",
     "debug": "2.2.0",
     "msgpack-js": "0.3.0",
-    "redis": "2.3.0",
+    "redis": "2.4.2",
     "socket.io-adapter": "0.4.0",
     "uid2": "0.0.3"
   },


### PR DESCRIPTION
This updates node-redis to the latest version