### PR TITLE
Add notes about protocol used for naming redis channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ prefix + '#' + namespace + '#' + room + '#'
 
 A number of other libraries adopt this protocol including:
 
-- [socket.io-redis](https://github.com/socketio/socket.io-emitter)
+- [socket.io-emitter](https://github.com/socketio/socket.io-emitter)
 - [socket.io-python-emitter](https://github.com/GameXG/socket.io-python-emitter)
 
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ multiple socket.io instances in different processes or servers that can
 all broadcast and emit events to and from each other.
 
 If you need to emit events to socket.io instances from a non-socket.io
-process, you should use [socket.io-emitter](https:///github.com/Automattic/socket.io-emitter).
+process, you should use [socket.io-emitter](https:///github.com/socket.io/socket.io-emitter).
 
 ## API
 
@@ -79,6 +79,29 @@ io.adapter(adapter({ pubClient: pub, subClient: sub }));
 ```
 
 Make sure the `return_buffers` option is set to `true` for the sub client.
+
+## Protocol
+
+The `socket.io-redis` adapter broadcasts and receives messages on particularly named Redis channels. For global broadcasts the channel name is:
+```
+prefix + '#' + namespace + '#'
+```
+
+In broadcasting to a single room the channel name is:
+```
+prefix + '#' + namespace + '#' + room + '#'
+```
+
+
+- `prefix`: The base channel name. Default value is `socket.io`. Changed by setting `opts.key` in `adapter(opts)` constructor
+- `namespace`: See https://github.com/socketio/socket.io#namespace.
+- `room` : Used if targeting a specific room.
+
+A number of other libraries adopt this protocol including:
+
+- [socket.io-redis](https://github.com/socketio/socket.io-emitter)
+- [socket.io-python-emitter](https://github.com/GameXG/socket.io-python-emitter)
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ multiple socket.io instances in different processes or servers that can
 all broadcast and emit events to and from each other.
 
 If you need to emit events to socket.io instances from a non-socket.io
-process, you should use [socket.io-emitter](https:///github.com/socket.io/socket.io-emitter).
+process, you should use [socket.io-emitter](https://github.com/socketio/socket.io-emitter).
 
 ## API
 


### PR DESCRIPTION
In version `0.2.0` there was a breaking change introduced that effected other libraries communicating with socket.io through Redis (https://github.com/socketio/socket.io-redis/issues/78). I have been spending a lot of time thinking about how this namespace change was able to break `socket.io-emitter`, how to learn from what happened, and hopefully how to prevent it from happening again. 

Here's what I think happened: This repository has created a **protocol** for communication via Redis to socket.io, and the protocol is used both in this repo, as well as in `socket.io-emitter` and `socket.io-python-emitter`. The protocol, specifically the construction of Redis channel names, changed and was not advertised in the release notes, and nobody really picked up in the fact that it would effect other libraries using the protocol (namely... the emitter libraries). 

- Should this protocol be documented so that changes to it in the future will have a better chance of being noticed?
- Where should the knowledge live that emitter depended on this repo (for the protocol)?
- How could we have prevented missing this bug? I did read the entire diff and even made a comment on the channel name changing but I failed to recognize the effects it would have on emitter.
- Should `socket.io-emitter` call out which versions of `socket.io-redis` it supports.