### PR TITLE
Fixes #93 by passing full URI to redis.createClient when specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ function adapter(uri, opts){
       // handle uri string
       return redis(uri, redis_opts);
     } else {
-      return redis(Number(opts.port || 6379), opts.host || '127.0.0.1', redis_opts);
+      var port = Number(opts.port || 6379);
+      var host = opts.host || '127.0.0.1';
+      return redis(port, host, redis_opts);
     }
   }
   

--- a/index.js
+++ b/index.js
@@ -45,9 +45,7 @@ function adapter(uri, opts){
       // handle uri string
       return redis(uri, redis_opts);
     } else {
-      var port = Number(opts.port || 6379);
-      var host = opts.host || '127.0.0.1';
-      return redis(port, host, redis_opts);
+      return redis(opts.port, opts.host, redis_opts);
     }
   }
   

--- a/index.js
+++ b/index.js
@@ -34,23 +34,23 @@ function adapter(uri, opts){
     uri = null;
   }
 
-  // handle uri string
-  if (uri) {
-    uri = uri.split(':');
-    opts.host = uri[0];
-    opts.port = uri[1];
-  }
-
   // opts
-  var host = opts.host || '127.0.0.1';
-  var port = Number(opts.port || 6379);
   var pub = opts.pubClient;
   var sub = opts.subClient;
   var prefix = opts.key || 'socket.io';
 
   // init clients if needed
-  if (!pub) pub = redis(port, host);
-  if (!sub) sub = redis(port, host, { return_buffers: true });
+  function createClient(redis_opts) {
+    if (uri) {
+      // handle uri string
+      return redis(uri, redis_opts);
+    } else {
+      return redis(Number(opts.port || 6379), opts.host || '127.0.0.1', redis_opts);
+    }
+  }
+  
+  if (!pub) pub = createClient();
+  if (!sub) sub = createClient({ return_buffers: true });
 
   // this server's key
   var uid = uid2(6);


### PR DESCRIPTION
My initial approach was to use `url.parse()` from the Node.js URL module to get the hostname and port. This did work, but I noticed that redis also lets you specify the database index and other options via the URL, so it seemed better to pass it wholesale to the `createClient` call if specified.