### PR TITLE
Add support to ioredis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ results
 
 npm-debug.log
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following options are allowed:
 - `key`: the name of the key to pub/sub events on as prefix (`socket.io`)
 - `host`: host to connect to redis on (`localhost`)
 - `port`: port to connect to redis on (`6379`)
+- `subEvent`: optional, the redis client event name to subscribe to (`message`)
 - `pubClient`: optional, the redis client to publish events on
 - `subClient`: optional, the redis client to subscribe to events on
 
@@ -41,6 +42,9 @@ with an equivalent API.
 
 If you supply clients, make sure you initialized them with 
 the `return_buffers` option set to `true`.
+
+You can supply [ioredis](https://github.com/luin/ioredis) as a client
+by providing `messageBuffer` as the subEvent option.
 
 ### RedisAdapter
 

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function adapter(uri, opts){
   var pub = opts.pubClient;
   var sub = opts.subClient;
   var prefix = opts.key || 'socket.io';
+  var subEvent = opts.subEvent || 'message';
 
   // init clients if needed
   if (!pub) pub = redis(port, host);
@@ -74,7 +75,7 @@ function adapter(uri, opts){
     sub.subscribe(prefix + '#' + nsp.name + '#', function(err){
       if (err) self.emit('error', err);
     });
-    sub.on('message', this.onmessage.bind(this));
+    sub.on(subEvent, this.onmessage.bind(this));
   }
 
   /**


### PR DESCRIPTION
Hi,
I added an option named subEvent, so we could supply an ioredis client by providing the proper event as discussed here https://github.com/socketio/socket.io-redis/issues/60.

With this option we could use ioredis directly which would be great as it's a well deserved redis client.