### PR TITLE
Use native JSON instead of MessagePack is faster

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@
 
 var uid2 = require('uid2');
 var redis = require('redis').createClient;
-var msgpack = require('msgpack-js');
 var Adapter = require('socket.io-adapter');
 var Emitter = require('events').EventEmitter;
 var debug = require('debug')('socket.io-redis');
@@ -91,7 +90,7 @@ function adapter(uri, opts){
    */
 
   Redis.prototype.onmessage = function(channel, msg){
-    var args = msgpack.decode(msg);
+    var args = JSON.parse(msg);
     var packet;
 
     if (uid == args.shift()) return debug('ignore same uid');
@@ -124,7 +123,7 @@ function adapter(uri, opts){
     Adapter.prototype.broadcast.call(this, packet, opts);
     if (!remote) {
       var chn = prefix + '#' + packet.nsp + '#';
-      var msg = msgpack.encode([uid, packet, opts]);
+      var msg = JSON.stringify([uid, packet, opts]);
       if (opts.rooms) {
         opts.rooms.forEach(function(room) {
           var chnRoom = chn + room + '#';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "async": "0.9.0",
     "debug": "2.2.0",
-    "msgpack-js": "0.3.0",
     "redis": "2.4.2",
     "socket.io-adapter": "0.4.0",
     "uid2": "0.0.3"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "async": "0.9.0",
     "debug": "2.2.0",
-    "redis": "2.4.2",
+    "redis": "^2.5.3",
     "socket.io-adapter": "0.4.0",
     "uid2": "0.0.3"
   },


### PR DESCRIPTION
Test source:
```javascript
var msgpackLite = require('msgpack-lite');
var msgpackJs = require('msgpack-js');
var Benchmark = require('benchmark');
var msgpack = require('msgpack');
var fs = require('fs');
var _ = require('lodash');

var testData = {
    blablabla: {
        hello: 'World',
        country: 255
    },
    x: 0,
    y: 253745
};

var suite = new Benchmark.Suite;
suite.add('MessagePack encode/decode', function() {
        var encoded = msgpack.pack(testData);
        var decoded = msgpack.unpack(encoded);
    })
    .add('MessagePackLite encode/decode', function() {
        var encoded = msgpackLite.encode(testData);
        var decoded = msgpackLite.decode(encoded);
    })
    .add('MessagePackJS encode/decode', function() {
        var encoded = msgpackJs.encode(testData);
        var decoded = msgpackJs.decode(encoded);
    })
    .add('JSON encode/decode', function() {
        var encoded = JSON.stringify(testData);
        var decoded = JSON.parse(encoded);
    })
    .on('cycle', function(event) {
        console.log(String(event.target));
    })
    .on('complete', function() {
        console.log('Fastest is ' + this.filter('fastest').map('name'));
    })
    .run({ 'async': false });
```

Test results:
```
MessagePack encode/decode x 70,190 ops/sec ±2.38% (87 runs sampled)
MessagePackLite encode/decode x 75,994 ops/sec ±2.36% (86 runs sampled)
MessagePackJS encode/decode x 34,879 ops/sec ±2.74% (90 runs sampled)
JSON encode/decode x 371,367 ops/sec ±1.71% (91 runs sampled)
Fastest is JSON encode/decode
```