### PR TITLE
Return early when channels mismatch to skip expensive msgpack decoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function adapter(uri, opts){
       }
     } else { // Fallback to slow indexOf impl for older Node.js
       this.channelMatches = function (messageChannel, subscribedChannel) {
-        return messageChannel.indexOf(subscribedChannel) === 0;
+        return messageChannel.substr(0, subscribedChannel.length) === subscribedChannel;
       }
     }
     this.pubClient = pub;

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function adapter(uri, opts){
       this.channelMatches = function (messageChannel, subscribedChannel) {
         return messageChannel.startsWith(subscribedChannel);
       }
-    } else { // Fallback to slow indexOf impl for older Node.js
+    } else { // Fallback to other impl for older Node.js
       this.channelMatches = function (messageChannel, subscribedChannel) {
         return messageChannel.substr(0, subscribedChannel.length) === subscribedChannel;
       }


### PR DESCRIPTION
Hopefully, the title says all.

Well, we're using a lot of namespaces. and there is performance problem.