### PR TITLE
Get all clients in a room across all nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ that a regular `Adapter` does not
 - `pubClient`
 - `subClient`
 
+RedisAdapter#clients(rooms:Array, fn:Function)
+
+Returns the list of client IDs connected to `rooms` across all nodes. See [Namespace#clients(fn:Function)](https://github.com/socketio/socket.io#namespaceclientsfnfunction)
+
 ## Client error handling
 
 Access the `pubClient` and `subClient` properties of the

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The following options are allowed:
 - `subEvent`: optional, the redis client event name to subscribe to (`message`)
 - `pubClient`: optional, the redis client to publish events on
 - `subClient`: optional, the redis client to subscribe to events on
+- `clientsTimeout`: optional, after this timeout the adapter will stop waiting from responses to `clients` request (`1000ms`)
 
 If you decide to supply `pubClient` and `subClient`, make sure you use
 [node_redis](https://github.com/mranney/node_redis) as a client or one
@@ -55,6 +56,7 @@ that a regular `Adapter` does not
 - `prefix`
 - `pubClient`
 - `subClient`
+- `clientsTimeout`
 
 RedisAdapter#clients(rooms:Array, fn:Function)
 

--- a/index.js
+++ b/index.js
@@ -147,7 +147,9 @@ function adapter(uri, opts){
 
   Redis.prototype.onclients = function(channel, msg){
 
-    if (!this.channelMatches(channel.toString(), this.syncChannel)) {
+    var self = this;
+
+    if (!self.channelMatches(channel.toString(), self.syncChannel)) {
       return debug('ignore different channel');
     }
 
@@ -158,7 +160,7 @@ function adapter(uri, opts){
       return;
     }
 
-    Adapter.prototype.clients.call(this, decoded.rooms, function(err, clients){
+    Adapter.prototype.clients.call(self, decoded.rooms, function(err, clients){
       if(err){
         self.emit('error', err);
         return;
@@ -318,14 +320,14 @@ function adapter(uri, opts){
       var msg_count = 0;
       var clients = {};
 
-      subJson.on("subscribe", function subscribed(channel, count) {
+      subJson.on('subscribe', function subscribed(channel, count) {
 
         var request = JSON.stringify({
           transaction : transaction,
           rooms : rooms
         });
 
-        /*If there is no response for 5 seconds, return result;*/
+        /*If there is no response for 1 second, return result;*/
         var timeout = setTimeout(function() {
           if (fn) process.nextTick(fn.bind(null, null, Object.keys(clients)));
         }, self.clientsTimeout);
@@ -337,6 +339,9 @@ function adapter(uri, opts){
           }
 
           var response = JSON.parse(msg);
+
+          //Ignore if response does not contain 'clients' key
+          if(!response.clients || !Array.isArray(response.clients)) return;
           
           for(var i = 0; i < response.clients.length; i++){
             clients[response.clients[i]] = true;

--- a/test/index.js
+++ b/test/index.js
@@ -113,6 +113,50 @@ describe('socket.io-redis', function(){
     });
   });
 
+  it('returns clients in the same room', function(done){
+    create(function(server1, client1){
+      create(function(server2, client2){
+        create(function(server3, client3){
+          
+          var ready = 0;
+
+          server1.on('connection', function(c1){
+            c1.join('woot');
+            ready++;;
+            if(ready === 3){
+              test();
+            }
+          });
+
+          server2.on('connection', function(c1){
+            c1.join('woot');
+            ready++;;
+            if(ready === 3){
+              test();
+            }
+          });
+
+          server3.on('connection', function(c3){
+            ready++;;
+            if(ready === 3){
+              test();
+            }
+          });
+
+          function test(){
+            setTimeout(function(){
+              server1.adapter.clients(['woot'], function(err, clients){
+                expect(clients.length).to.eql(2);
+                done();
+              })
+            }, 100);
+          }
+
+        });
+      });
+    });
+  });
+
   // create a pair of socket.io server+client
   function create(nsp, fn){
     var srv = http();


### PR DESCRIPTION
This pull request adds the ability to get all clients IDs connected to a room or rooms. It's up to date with `Adapter` so a call to [Namespace#clients(fn:Function)](https://github.com/socketio/socket.io#namespaceclientsfnfunction) will return the same result as `RedisAdapter.clients(rooms:Array, fn:Function)`