### PR TITLE
sometimes we need auth_pass and db options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ var redis = require('socket.io-redis');
 io.adapter(redis({ host: 'localhost', port: 6379 }));
 ```
 
+If you need auth_pass or db options, please use adapter instead of passing redis parameter:
+
+```js
+var redis = require('redis').createClient;
+var adapter = require('socket.io-redis');
+var pub = redis(port, host, { auth_pass: "pwd", db: 8 });
+var sub = redis(port, host, { return_buffers: true, auth_pass: "pwd", db: 9 });
+io.adapter(adapter({ pubClient: pub, subClient: sub }));
+```
+
 By running socket.io with the `socket.io-redis` adapter you can run
 multiple socket.io instances in different processes or servers that can
 all broadcast and emit events to and from each other.

--- a/index.js
+++ b/index.js
@@ -50,8 +50,11 @@ function adapter(uri, opts){
     }
   }
   
-  if (!pub) pub = createClient();
-  if (!sub) sub = createClient({ return_buffers: true });
+  if (!pub) pub = createClient(opts);
+  if (!sub) {
+  	opts.return_buffers = true;
+  	sub = createClient(opts);
+  }
 
   // this server's key
   var uid = uid2(6);


### PR DESCRIPTION
var app = require('express')();
var http = require('http').Server(app);
var io = require('socket.io')(http);
var redis = require('socket.io-redis');

io.adapter(redis({ host:'127.0.0.1', port:6379, auth_pass:'abcd_1234', db:9 }));

If there is auth_pass options, the response is :
D:\Develop\nodeJS\chat-example>node index
listening on *:3000
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: Ready check failed: NOAUTH Authentication required.
    at JavascriptReplyParser._parseResult (D:\Develop\nodeJS\chat-example\node_modules\redis\lib\parsers\javascript.js:37:16)
    at JavascriptReplyParser.execute (D:\Develop\nodeJS\chat-example\node_modules\redis\lib\parsers\javascript.js:113:38)
    at Socket.<anonymous> (D:\Develop\nodeJS\chat-example\node_modules\redis\index.js:117:27)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:172:18)
    at Socket.Readable.push (_stream_readable.js:130:10)
    at TCP.onread (net.js:535:20)
