### PR TITLE
Fix an issue when broadcasting binary data between nodes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ function adapter(uri, opts){
    */
 
   Redis.prototype.broadcast = function(packet, opts, remote){
-    Adapter.prototype.broadcast.call(this, packet, opts);
+    packet.nsp = this.nsp.name;
     if (!remote) {
       var chn = prefix + '#' + packet.nsp + '#';
       var msg = msgpack.encode([uid, packet, opts]);
@@ -147,6 +147,7 @@ function adapter(uri, opts){
         pub.publish(chn, msg);
       }
     }
+    Adapter.prototype.broadcast.call(this, packet, opts);
   };
 
   /**

--- a/test/index.js
+++ b/test/index.js
@@ -11,15 +11,17 @@ describe('socket.io-redis', function(){
   it('broadcasts', function(done){
     create(function(server1, client1){
       create(function(server2, client2){
-        client1.on('woot', function(a, b){
+        client1.on('woot', function(a, b, c){
           expect(a).to.eql([]);
           expect(b).to.eql({ a: 'b' });
+          expect(Buffer.isBuffer(c)).to.be(true);
           client1.disconnect();
           client2.disconnect();
           done();
         });
         server2.on('connection', function(c2){
-          c2.broadcast.emit('woot', [], { a: 'b' });
+          var buf = new Buffer('asdfasdf', 'utf8');
+          c2.broadcast.emit('woot', [], { a: 'b' }, buf);
         });
       });
     });


### PR DESCRIPTION
It seems `Adapter.prototype.broadcast.call(this, packet, opts);` actually modifies the `packet` object, by removing any binary data attached.

Reference: https://github.com/socketio/socket.io-parser/blob/master/index.js#L196

Fix #112, close #113 