### PR TITLE
the client doesn't have the password?

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ function adapter(uri, opts){
     }
   }
   
-  if (!pub) pub = createClient();
-  if (!sub) sub = createClient({ return_buffers: true });
+  if (!pub) pub = createClient(opts);
+  if (!sub) sub = createClient(opts);
   
   var subJson = sub.duplicate({ return_buffers: false });
 


### PR DESCRIPTION
var pub = new redis({
    host: _host,
    port: _port,
    password: "redis_pass",
    db: 14
});
var sub = new redis({
    host: _host,
    port: _port,
    password: "redis_pass",
    db: 14
});
io = require('socket.io')(server);
var opts = {
         host: _host,
         port: _port
    // pubClient: pub,
    // subClient: sub
};
io.adapter(socketadapter(opts));
if the redis server doesn't need password, It's ok.

but if the redis server require password,  I get this Error: Ready check failed: NOAUTH Authentication required

I use this config: 
var pub = new redis({
    host: _host,
    port: _port,
    password: "redis_pass",
    db: 14
});
var sub = new redis({
    host: _host,
    port: _port,
    password: "redis_pass",
    db: 14
});
io = require('socket.io')(server);
var opts = {
    pubClient: pub,
    subClient: sub
};
io.adapter(socketadapter(opts));
but if I config the opts = { pubCliet: pub, subCliet: sub },  I get this Error

D:\code\test_socket.io_redis\8001\node_modules\msgpack-js\msgpack.js:200
  if (decoder.offset !== buffer.length) throw new Error((buffer.length - decoder.offset) + " trailing bytes");
                                        ^
Error: 95 trailing bytes
    at Object.decode (D:\code\test_socket.io_redis\8001\node_modules\msgpack-js\msgpack.js:200:47)
    at Redis.onmessage (D:\code\test_socket.io_redis\8001\node_modules\socket.io-redis\index.js:121:24)
    at emitTwo (events.js:106:13)
    at Redis.emit (events.js:191:7)
    at Redis.exports.returnReply (D:\code\test_socket.io_redis\8001\node_modules\ioredis\lib\redis\parser.js:114:14)
    at JavascriptReplyParser.replyParser.Parser.returnReply (D:\code\test_socket.io_redis\8001\node_modules\ioredis\lib\redis\parser.js:28:13)
    at JavascriptReplyParser.run (D:\code\test_socket.io_redis\8001\node_modules\ioredis\node_modules\redis-parser\lib\javascript.js:137:18)
    at JavascriptReplyParser.execute (D:\code\test_socket.io_redis\8001\node_modules\ioredis\node_modules\redis-parser\lib\javascript.js:112:10)
    at Socket.<anonymous> (D:\code\test_socket.io_redis\8001\node_modules\ioredis\lib\redis\event_handler.js:107:22)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:172:18)
    at Socket.Readable.push (_stream_readable.js:130:10)
    at TCP.onread (net.js:542:20)

so, how can i fix this bug ?   if you know please let me know, thanks!
