### PR TITLE
Add support for custom data when returning a list of all socket clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "async": "0.9.0",
     "debug": "2.3.3",
     "msgpack-js": "0.3.0",
-    "redis": "2.4.2",
+    "redis": "2.6.3",
     "socket.io-adapter": "0.5.0",
     "uid2": "0.0.3"
   },


### PR DESCRIPTION
We have a use case when a new client connects to a socket.io server, it would like to know all the clients that are in a particular room, and some metadata of the clients on the other side. So we implemented a custom hook function that enables the consumer of the 'clients' call on the adapter to implement custom callback to fetch client metadata in addition to the clientIDs.