### PR TITLE
numsub and msgCount are different type

### DIFF
--- a/index.js
+++ b/index.js
@@ -408,7 +408,7 @@ function adapter(uri, opts){
         return;
       }
 
-      numsub = numsub[1];
+      numsub = parseInt(numsub[1], 10);
 
       var request = JSON.stringify({
         requestid : requestid,


### PR DESCRIPTION
This was causing a timeout error on `.clients` and `.clientRooms` because of this check https://github.com/socketio/socket.io-redis/blob/f2dd9fea22963a697666f135247d6f0de1ee7f29/index.js#L252-Lundefined

`request.msgCount` was an int and `request.numsub` was a string.