### PR TITLE
Replace msgpack with msgpack-lite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - "0.10"
   - "0.12"
   - "4"
+  - "6"
+  - "7"
 notifications:
   irc: "irc.freenode.org#socket.io"
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ node_js:
   - "0.10"
   - "0.12"
   - "4"
-  - "6"
-  - "7"
 notifications:
   irc: "irc.freenode.org#socket.io"
 services:

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 
 var uid2 = require('uid2');
 var redis = require('redis').createClient;
-var msgpack = require('msgpack-js');
+var msgpack = require('msgpack-lite');
 var Adapter = require('socket.io-adapter');
 var debug = require('debug')('socket.io-redis');
 var async = require('async');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "async": "2.1.4",
     "debug": "2.3.3",
-    "msgpack-js": "0.3.0",
+    "msgpack-lite": "0.1.26",
     "redis": "2.6.3",
     "socket.io-adapter": "0.5.0",
     "uid2": "0.0.3"


### PR DESCRIPTION
Fixes #40. Alternative to #105.

My benchmarks showed `msgpack-lite` being a little bit faster encoding and a little bit slower decoding than `msgpack`. `msgpack5` on the other hand was 5x slower doing both. 