### PR TITLE
subEvent now defaults to `messageBuffer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following options are allowed:
 - `key`: the name of the key to pub/sub events on as prefix (`socket.io`)
 - `host`: host to connect to redis on (`localhost`)
 - `port`: port to connect to redis on (`6379`)
-- `subEvent`: optional, the redis client event name to subscribe to (`message`)
+- `subEvent`: optional, the redis client event name to subscribe to (`messageBuffer`)
 - `pubClient`: optional, the redis client to publish events on
 - `subClient`: optional, the redis client to subscribe to events on
 - `requestsTimeout`: optional, after this timeout the adapter will stop waiting from responses to request (`1000ms`)
@@ -41,12 +41,6 @@ The following options are allowed:
 If you decide to supply `pubClient` and `subClient`, make sure you use
 [node_redis](https://github.com/mranney/node_redis) as a client or one
 with an equivalent API.
-
-If you supply clients, make sure you initialized them with 
-the `return_buffers` option set to `true`.
-
-You can supply [ioredis](https://github.com/luin/ioredis) as a client
-by providing `messageBuffer` as the subEvent option.
 
 ### RedisAdapter
 
@@ -89,11 +83,9 @@ a connection string.
 var redis = require('redis').createClient;
 var adapter = require('socket.io-redis');
 var pub = redis(port, host, { auth_pass: "pwd" });
-var sub = redis(port, host, { return_buffers: true, auth_pass: "pwd" });
+var sub = redis(port, host, { auth_pass: "pwd" });
 io.adapter(adapter({ pubClient: pub, subClient: sub }));
 ```
-
-Make sure the `return_buffers` option is set to `true` for the sub client.
 
 ## Protocol
 

--- a/index.js
+++ b/index.js
@@ -47,22 +47,22 @@ function adapter(uri, opts){
   var sub = opts.subClient;
 
   var prefix = opts.key || 'socket.io';
-  var subEvent = opts.subEvent || 'message';
+  var subEvent = opts.subEvent || 'messageBuffer';
   var requestsTimeout = opts.requestsTimeout || 1000;
   var withChannelMultiplexing = false !== opts.withChannelMultiplexing;
 
   // init clients if needed
-  function createClient(redis_opts) {
+  function createClient() {
     if (uri) {
       // handle uri string
-      return redis(uri, redis_opts);
+      return redis(uri, opts);
     } else {
-      return redis(opts.port, opts.host, redis_opts);
+      return redis(opts);
     }
   }
 
   if (!pub) pub = createClient();
-  if (!sub) sub = createClient({ return_buffers: true });
+  if (!sub) sub = createClient();
 
   // this server's key
   var uid = uid2(6);

--- a/test/index.js
+++ b/test/index.js
@@ -12,10 +12,7 @@ var adapter = require('../');
       var redis = require('redis').createClient;
       var srv = http();
       var sio = io(srv);
-      sio.adapter(adapter({
-        pubClient: redis(),
-        subClient: redis(null, null, { return_buffers: true })
-      }));
+      sio.adapter(adapter());
       srv.listen(function(err){
         if (err) throw err; // abort tests
         if ('function' == typeof nsp) {
@@ -32,12 +29,9 @@ var adapter = require('../');
   {
     name: 'socket.io-redis without channel multiplexing',
     create: function create(nsp, fn){
-      var redis = require('redis').createClient;
       var srv = http();
       var sio = io(srv);
       sio.adapter(adapter({
-        pubClient: redis(),
-        subClient: redis(null, null, { return_buffers: true }),
         withChannelMultiplexing: false
       }));
       srv.listen(function(err){
@@ -61,8 +55,7 @@ var adapter = require('../');
       var sio = io(srv);
       sio.adapter(adapter({
         pubClient: redis(),
-        subClient: redis(null, null, { return_buffers: true }),
-        subEvent: 'messageBuffer'
+        subClient: redis(),
       }));
       srv.listen(function(err){
         if (err) throw err; // abort tests


### PR DESCRIPTION
With that subscription event the `return_buffers` flag is not needed anymore.

Closes https://github.com/socketio/socket.io-redis/issues/91
Also closes https://github.com/socketio/socket.io-redis/pull/116