### PR TITLE
https://github.com/socketio/socket.io-redis/issues/211

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,23 +233,23 @@ function adapter(uri, opts) {
         var socket = this.nsp.connected[request.sid];
         if (!socket) { return; }
 
-          socket.join(request.room, function () {
-            var response = JSON.stringify({
-                requestid: request.requestid
-            });
-
-            pub.publish(self.responseChannel, response);
+        socket.join(request.room, function(){
+          var response = JSON.stringify({
+            requestid: request.requestid
           });
-          break;
+
+          pub.publish(self.responseChannel, response);
+        });
+        break;
 
       case requestTypes.remoteLeave:
 
         var socket = this.nsp.connected[request.sid];
         if (!socket) { return; }
 
-        socket.leave(request.room, function () {
+        socket.leave(request.room, function(){
           var response = JSON.stringify({
-              requestid: request.requestid
+            requestid: request.requestid
           });
 
           pub.publish(self.responseChannel, response);

--- a/index.js
+++ b/index.js
@@ -233,31 +233,29 @@ function adapter(uri, opts) {
         var socket = this.nsp.connected[request.sid];
         if (!socket) { return; }
 
-        function sendAck(){
-          var response = JSON.stringify({
-            requestid: request.requestid
+          socket.join(request.room, function () {
+            var response = JSON.stringify({
+                requestid: request.requestid
+            });
+
+            pub.publish(self.responseChannel, response);
           });
-
-          pub.publish(self.responseChannel, response);
-        }
-
-        socket.join(request.room, sendAck);
-        break;
+          break;
 
       case requestTypes.remoteLeave:
 
         var socket = this.nsp.connected[request.sid];
-        if (!socket) { return; }
+        if (!socket) {
+            return;
+        }
 
-        function sendAck(){
+        socket.leave(request.room, function () {
           var response = JSON.stringify({
-            requestid: request.requestid
+              requestid: request.requestid
           });
 
           pub.publish(self.responseChannel, response);
-        }
-
-        socket.leave(request.room, sendAck);
+        });
         break;
 
       case requestTypes.remoteDisconnect:

--- a/index.js
+++ b/index.js
@@ -245,9 +245,7 @@ function adapter(uri, opts) {
       case requestTypes.remoteLeave:
 
         var socket = this.nsp.connected[request.sid];
-        if (!socket) {
-            return;
-        }
+        if (!socket) { return; }
 
         socket.leave(request.room, function () {
           var response = JSON.stringify({

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "expect.js": "0.3.1",
     "ioredis": "2.5.0",
     "mocha": "3.2.0",
-    "socket.io": "socketio/socket.io",
-    "socket.io-client": "socketio/socket.io-client"
+    "socket.io": "1.7.x",
+    "socket.io-client": "1.7.x"
   }
 }


### PR DESCRIPTION
Starting from version 3.0 (2.0.1 works fine) on some systems socket.io-redis package fatals with error **SyntaxError: Identifier 'sendAck' has already been declared**, this pull request solves this problem, sendAck methods changed with anonymous versions.