### PR TITLE
Use pattern matching at the namespace level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"
   - "node"

--- a/README.md
+++ b/README.md
@@ -32,11 +32,9 @@ The following options are allowed:
 - `key`: the name of the key to pub/sub events on as prefix (`socket.io`)
 - `host`: host to connect to redis on (`localhost`)
 - `port`: port to connect to redis on (`6379`)
-- `subEvent`: optional, the redis client event name to subscribe to (`messageBuffer`)
 - `pubClient`: optional, the redis client to publish events on
 - `subClient`: optional, the redis client to subscribe to events on
 - `requestsTimeout`: optional, after this timeout the adapter will stop waiting from responses to request (`1000ms`)
-- `withChannelMultiplexing`: optional, whether channel multiplexing is enabled (a new subscription will be trigggered for each room) (`true`)
 
 If you decide to supply `pubClient` and `subClient`, make sure you use
 [node_redis](https://github.com/mranney/node_redis) as a client or one

--- a/index.js
+++ b/index.js
@@ -136,6 +136,10 @@ function adapter(uri, opts) {
   Redis.prototype.onmessage = function(pattern, channel, msg){
     channel = channel.toString();
 
+    if (!this.channelMatches(channel, this.channel)) {
+      return debug('ignore different channel');
+    }
+
     var room = channel.substring(this.channel.length);
     if (room !== '' && !this.rooms.hasOwnProperty(room)) {
       return debug('ignore unknown room %s', room);
@@ -172,6 +176,8 @@ function adapter(uri, opts) {
 
     if (this.channelMatches(channel, this.responseChannel)) {
       return this.onresponse(channel, msg);
+    } else if (!this.channelMatches(channel, this.requestChannel)) {
+      return debug('ignore different channel');
     }
 
     var self = this;

--- a/package.json
+++ b/package.json
@@ -14,11 +14,10 @@
     "test": "mocha"
   },
   "dependencies": {
-    "async": "2.1.4",
     "debug": "2.3.3",
     "msgpack-lite": "0.1.26",
     "redis": "2.6.3",
-    "socket.io-adapter": "0.5.0",
+    "socket.io-adapter": "~1.1.0",
     "uid2": "0.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "expect.js": "0.3.1",
     "ioredis": "2.5.0",
     "mocha": "3.2.0",
-    "socket.io": "1.7.x",
-    "socket.io-client": "1.7.x"
+    "socket.io": "latest",
+    "socket.io-client": "latest"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -169,6 +169,26 @@ var socket1, socket2, socket3;
       });
     });
 
+    it('ignores messages from unknown channels', function(done){
+      namespace1.adapter.subClient.psubscribe('f?o', function () {
+        namespace3.adapter.pubClient.publish('foo', 'bar');
+      });
+
+      namespace1.adapter.subClient.on('pmessageBuffer', function () {
+        setTimeout(done, 50);
+      });
+    });
+
+    it('ignores messages from unknown channels (2)', function(done){
+      namespace1.adapter.subClient.subscribe('woot', function () {
+        namespace3.adapter.pubClient.publish('woot', 'toow');
+      });
+
+      namespace1.adapter.subClient.on('messageBuffer', function () {
+        setTimeout(done, 50);
+      });
+    });
+
     describe('rooms', function () {
       it('returns rooms of a given client', function(done){
         socket1.join('woot1', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -16,12 +16,6 @@ var socket1, socket2, socket3;
     name: 'socket.io-redis'
   },
   {
-    name: 'socket.io-redis without channel multiplexing',
-    options: {
-      withChannelMultiplexing: false
-    }
-  },
-  {
     name: 'socket.io-redis with ioredis',
     options: function () {
       return {
@@ -152,7 +146,7 @@ var socket1, socket2, socket3;
     it('deletes rooms upon disconnection', function(done){
       socket1.join('woot');
       socket1.on('disconnect', function() {
-        expect(socket1.adapter.sids[socket1.id]).to.be.empty();
+        expect(socket1.adapter.sids[socket1.id]).to.be(undefined);
         expect(socket1.adapter.rooms).to.be.empty();
         client1.disconnect();
         done();
@@ -200,6 +194,7 @@ var socket1, socket2, socket3;
       it('returns all rooms accross several nodes', function(done){
         socket1.join('woot1', function () {
           namespace1.adapter.allRooms(function(err, rooms){
+            expect(err).to.be(null);
             expect(rooms).to.have.length(4);
             expect(rooms).to.contain(socket1.id);
             expect(rooms).to.contain(socket2.id);
@@ -212,6 +207,7 @@ var socket1, socket2, socket3;
 
       it('makes a given socket join a room', function(done){
         namespace3.adapter.remoteJoin(socket1.id, 'woot3', function(err){
+          expect(err).to.be(null);
           var rooms = Object.keys(socket1.rooms);
           expect(rooms).to.have.length(2);
           expect(rooms).to.contain('woot3');
@@ -222,6 +218,7 @@ var socket1, socket2, socket3;
       it('makes a given socket leave a room', function(done){
         socket1.join('woot3', function(){
           namespace3.adapter.remoteLeave(socket1.id, 'woot3', function(err){
+            expect(err).to.be(null);
             var rooms = Object.keys(socket1.rooms);
             expect(rooms).to.have.length(1);
             expect(rooms).not.to.contain('woot3');
@@ -237,6 +234,7 @@ var socket1, socket2, socket3;
         }
 
         namespace3.adapter.customRequest('hello', function(err, replies){
+          expect(err).to.be(null);
           expect(replies).to.have.length(3);
           expect(replies).to.contain(namespace1.adapter.uid);
           done();
@@ -297,7 +295,7 @@ function init(options){
           socket1 = _socket1;
           socket2 = _socket2;
           socket3 = _socket3;
-          done();
+          setTimeout(done, 100);
         });
       });
     });


### PR DESCRIPTION
This follows #46. Each node will now listen to only three channels:

- `socket.io#<namespace>#*`: used when broadcasting
- `socket.io-request#<namespace>#`: used for requesting information (ex: get every room in the cluster)
- `socket.io-response#<namespace>#`: used for responding to requests

We keep the benefits of #46 since:

- messages from other namespaces are ignored
- when emitting to a single room, the message is sent to
  `socket.io#<namespace>#<my-room>`, so listeners can check whether they
  have the room before unpacking the message (which is CPU consuming).

But there is no need to subscribe / unsubscribe every time a socket
joins or leaves a room (which is also CPU consuming when there are
thousands of subscriptions).