### PR TITLE
Uses the requestid from response when deleting requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -307,7 +307,6 @@ function adapter(uri, opts) {
   Redis.prototype.onresponse = function(channel, msg){
     var self = this;
     var response;
-    var requestid;
 
     try {
       response = JSON.parse(msg);
@@ -316,12 +315,12 @@ function adapter(uri, opts) {
       return;
     }
 
-    if (!response.requestid || !self.requests[response.requestid]) {
+    var requestid = response.requestid;
+
+    if (!requestid || !self.requests[requestid]) {
       debug('ignoring unknown request');
       return;
     }
-
-    requestid = response.requestid;
 
     debug('received response %j', response);
 

--- a/index.js
+++ b/index.js
@@ -307,6 +307,7 @@ function adapter(uri, opts) {
   Redis.prototype.onresponse = function(channel, msg){
     var self = this;
     var response;
+    var requestid;
 
     try {
       response = JSON.parse(msg);
@@ -319,6 +320,8 @@ function adapter(uri, opts) {
       debug('ignoring unknown request');
       return;
     }
+
+    requestid = response.requestid;
 
     debug('received response %j', response);
 
@@ -339,14 +342,14 @@ function adapter(uri, opts) {
         if (request.msgCount === request.numsub) {
           clearTimeout(request.timeout);
           if (request.callback) process.nextTick(request.callback.bind(null, null, Object.keys(request.clients)));
-          delete self.requests[request.requestid];
+          delete self.requests[requestid];
         }
         break;
 
       case requestTypes.clientRooms:
         clearTimeout(request.timeout);
         if (request.callback) process.nextTick(request.callback.bind(null, null, response.rooms));
-        delete self.requests[request.requestid];
+        delete self.requests[requestid];
         break;
 
       case requestTypes.allRooms:
@@ -362,7 +365,7 @@ function adapter(uri, opts) {
         if (request.msgCount === request.numsub) {
           clearTimeout(request.timeout);
           if (request.callback) process.nextTick(request.callback.bind(null, null, Object.keys(request.rooms)));
-          delete self.requests[request.requestid];
+          delete self.requests[requestid];
         }
         break;
 
@@ -371,7 +374,7 @@ function adapter(uri, opts) {
       case requestTypes.remoteDisconnect:
         clearTimeout(request.timeout);
         if (request.callback) process.nextTick(request.callback.bind(null, null));
-        delete self.requests[request.requestid];
+        delete self.requests[requestid];
         break;
 
       case requestTypes.customRequest:
@@ -382,7 +385,7 @@ function adapter(uri, opts) {
         if (request.msgCount === request.numsub) {
           clearTimeout(request.timeout);
           if (request.callback) process.nextTick(request.callback.bind(null, null, request.replies));
-          delete self.requests[request.requestid];
+          delete self.requests[requestid];
         }
         break;
 

--- a/index.js
+++ b/index.js
@@ -324,7 +324,7 @@ function adapter(uri, opts) {
 
     debug('received response %j', response);
 
-    var request = self.requests[response.requestid];
+    var request = self.requests[requestid];
 
     switch (request.type) {
 

--- a/test/index.js
+++ b/test/index.js
@@ -220,6 +220,7 @@ var socket1, socket2, socket3;
             expect(rooms).to.contain(socket2.id);
             expect(rooms).to.contain(socket3.id);
             expect(rooms).to.contain('woot1');
+            expect(namespace1.adapter.requests).to.be.empty();
             done();
           });
         });


### PR DESCRIPTION
Request object does not have a `.requestid` property so requests were not being cleaned up and `.requests` was leaking memory in every `Redis` instance.

Fixes #224