### PR TITLE
Add support for using a different encoder via an option

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ function adapter(uri, opts) {
   var sub = opts.subClient;
   var prefix = opts.key || 'socket.io';
   var requestsTimeout = opts.requestsTimeout || 1000;
+  var encoder = opts.encoder || msgpack;
 
   // init clients if needed
   function createClient() {
@@ -145,7 +146,7 @@ function adapter(uri, opts) {
       return debug('ignore unknown room %s', room);
     }
 
-    var args = msgpack.decode(msg);
+    var args = encoder.decode(msg);
     var packet;
 
     if (uid === args.shift()) return debug('ignore same uid');
@@ -405,7 +406,7 @@ function adapter(uri, opts) {
   Redis.prototype.broadcast = function(packet, opts, remote){
     packet.nsp = this.nsp.name;
     if (!(remote || (opts && opts.flags && opts.flags.local))) {
-      var msg = msgpack.encode([uid, packet, opts]);
+      var msg = encoder.encode([uid, packet, opts]);
       var channel = this.channel;
       if (opts.rooms && opts.rooms.length === 1) {
         channel += opts.rooms[0] + '#';

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "ioredis": "^3.1.1",
     "mocha": "^3.4.2",
     "socket.io": "latest",
-    "socket.io-client": "latest"
+    "socket.io-client": "latest",
+    "msgpack-lite": "latest"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ var io = require('socket.io');
 var ioc = require('socket.io-client');
 var expect = require('expect.js');
 var adapter = require('../');
+var msgpackLite = require('msgpack-lite');
 
 var ioredis = require('ioredis').createClient;
 
@@ -24,6 +25,14 @@ var socket1, socket2, socket3;
       }
     }
   },
+  {
+    name: 'socket.io-redis with msgpack-lite',
+    options: function () {
+      return {
+        encoder: msgpackLite
+      }
+    }
+  }
 ].forEach(function (suite) {
   var name = suite.name;
   var options = suite.options;
@@ -38,7 +47,9 @@ var socket1, socket2, socket3;
         expect(a).to.eql([]);
         expect(b).to.eql({ a: 'b' });
         expect(Buffer.isBuffer(c) && c.equals(buf)).to.be(true);
-        expect(Buffer.isBuffer(d) && d.equals(Buffer.from(array))).to.be(true); // converted to Buffer on the client-side
+        if(name !== 'socket.io-redis with msgpack-lite') {
+          expect(Buffer.isBuffer(d) && d.equals(Buffer.from(array))).to.be(true); // converted to Buffer on the client-side
+        }
         done();
       });
 


### PR DESCRIPTION
The notepack.io implementation of msgpack is performant, but it's not very compatible with msgpack implementations that exist on other platforms.

This commit adds the ability to supply a new option `encoder` that allows you to replace notepack with your own implementation.  It adds a test for using this option to encode/decode with msgpack-lite.