### PR TITLE
[chore] Bump debug to version 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "debug": "~3.1.0",
+    "debug": "~4.1.0",
     "notepack.io": "~2.1.2",
     "redis": "~2.8.0",
     "socket.io-adapter": "~1.1.0",


### PR DESCRIPTION
Syncing the version of debug throughout the repositories.
https://github.com/socketio/engine.io/pull/581
https://github.com/socketio/socket.io-client/pull/1304
https://github.com/socketio/socket.io-parser/pull/92
https://github.com/socketio/engine.io-client/pull/612
https://github.com/socketio/socket.io-emitter/pull/82