### PR TITLE
uid-safe instead of uid2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "notepack.io": "~2.1.2",
     "redis": "~2.8.0",
     "socket.io-adapter": "~1.1.0",
-    "uid2": "0.0.3"
+    "uid-safe": "~2.1.5"
   },
   "devDependencies": {
     "expect.js": "0.3.1",


### PR DESCRIPTION
uid-safe
Create cryptographically secure UIDs safe for both cookie and URL usage. This is in contrast to modules such as rand-token and uid2 whose UIDs are actually skewed due to the use of % and unnecessarily truncate the UID. Use this if you could still use UIDs with - and _ in them.

(uid2 hasn't been updated in 6 years)