### PR TITLE
[fix] Update the way to calculate numsub (#267, #210)

### DIFF
--- a/index.js
+++ b/index.js
@@ -416,6 +416,41 @@ function adapter(uri, opts) {
     Adapter.prototype.broadcast.call(this, packet, opts);
   };
 
+
+  /**
+   * Get the number of subscribers of a channel
+   *
+   * @param {String} channel
+   */
+
+  async function getNumSub(channel){
+    if(pub.constructor.name != 'Cluster'){
+      // RedisClient or Redis
+      return new Promise(function(resolve,reject) {
+        pub.send_command('pubsub', ['numsub', channel], function(err, numsub){
+          if (err) return reject(err);
+          resolve(parseInt(numsub[1], 10));
+        });
+      })
+    }else{
+      // Cluster
+      var nodes = pub.nodes();
+      return Promise.all(
+        nodes.map(function(node) {
+          return node.send_command('pubsub', ['numsub', channel]);
+        })
+      ).then(function(values) {
+        var numsub = 0;
+        values.map(function(value){
+          numsub +=  parseInt(value[1], 10);
+        })
+        return numsub;
+      }).catch(function(err){
+        throw err;
+      });
+    }
+  }
+
   /**
    * Gets a list of clients by sid.
    *
@@ -435,14 +470,7 @@ function adapter(uri, opts) {
     var self = this;
     var requestid = uid2(6);
 
-    pub.send_command('pubsub', ['numsub', self.requestChannel], function(err, numsub){
-      if (err) {
-        self.emit('error', err);
-        if (fn) fn(err);
-        return;
-      }
-
-      numsub = parseInt(numsub[1], 10);
+    getNumSub(self.requestChannel).then(numsub => {
       debug('waiting for %d responses to "clients" request', numsub);
 
       var request = JSON.stringify({
@@ -468,6 +496,9 @@ function adapter(uri, opts) {
       };
 
       pub.publish(self.requestChannel, request);
+    }).catch(err => {
+      self.emit('error', err);
+      if (fn) fn(err);
     });
   };
 
@@ -524,14 +555,9 @@ function adapter(uri, opts) {
     var self = this;
     var requestid = uid2(6);
 
-    pub.send_command('pubsub', ['numsub', self.requestChannel], function(err, numsub){
-      if (err) {
-        self.emit('error', err);
-        if (fn) fn(err);
-        return;
-      }
+    getNumSub(self.requestChannel).then(numsub => {
+      console.log("NUMSUB : " + numsub);
 
-      numsub = parseInt(numsub[1], 10);
       debug('waiting for %d responses to "allRooms" request', numsub);
 
       var request = JSON.stringify({
@@ -556,6 +582,9 @@ function adapter(uri, opts) {
       };
 
       pub.publish(self.requestChannel, request);
+    }).catch(err => {
+      self.emit('error', err);
+      if (fn) fn(err);
     });
   };
 
@@ -700,14 +729,7 @@ function adapter(uri, opts) {
     var self = this;
     var requestid = uid2(6);
 
-    pub.send_command('pubsub', ['numsub', self.requestChannel], function(err, numsub){
-      if (err) {
-        self.emit('error', err);
-        if (fn) fn(err);
-        return;
-      }
-
-      numsub = parseInt(numsub[1], 10);
+    getNumSub(self.requestChannel).then(numsub => {
       debug('waiting for %d responses to "customRequest" request', numsub);
 
       var request = JSON.stringify({
@@ -733,6 +755,9 @@ function adapter(uri, opts) {
       };
 
       pub.publish(self.requestChannel, request);
+    }).catch(err => {
+      self.emit('error', err);
+      if (fn) fn(err);
     });
   };
 

--- a/index.js
+++ b/index.js
@@ -423,7 +423,7 @@ function adapter(uri, opts) {
    * @param {String} channel
    */
 
-  async function getNumSub(channel){
+  function getNumSub(channel){
     if(pub.constructor.name != 'Cluster'){
       // RedisClient or Redis
       return new Promise(function(resolve,reject) {
@@ -556,8 +556,6 @@ function adapter(uri, opts) {
     var requestid = uid2(6);
 
     getNumSub(self.requestChannel).then(numsub => {
-      console.log("NUMSUB : " + numsub);
-
       debug('waiting for %d responses to "allRooms" request', numsub);
 
       var request = JSON.stringify({


### PR DESCRIPTION
In order to solve the issues #267 and #210 I added a function in charge of the calculation of the numsub.

The function will:
- Check the configuration of redis (standalone, sentinel or cluster).
- If the configuration is cluster, send "pubsub numsub channel" to all the nodes of the cluster.
- Make the sum of all the responses.
- Return the value of numsub.

I tried it on the diferent configurations and it seems to work.

I couldn't run the test on my local for the master so I didn't do it for my changes.

It is my first contribution so if you have any advice you're welcome !