### PR TITLE
Use server/namespace to broadcast

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -346,7 +346,7 @@ export class RedisAdapter extends Adapter {
     if (!onlyLocal) {
       const rawOpts = {
         rooms: [...opts.rooms],
-        except: [...opts.except],
+        except: [...new Set(opts.except)],
         flags: opts.flags,
       };
       const msg = msgpack.encode([this.uid, packet, rawOpts]);

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,26 @@ let socket1, socket2, socket3;
       });
     });
 
+    it("uses a namespace to broadcast to rooms", () => {
+      socket1.join("woot");
+      client2.emit("do broadcast");
+      socket2.on("do broadcast", () => {
+        namespace2.to("woot").emit("broadcast");
+      });
+
+      client1.on("broadcast", () => {
+        setTimeout(done, 100);
+      });
+
+      client2.on("broadcast", () => {
+        throw new Error("Not in room");
+      });
+
+      client3.on("broadcast", () => {
+        throw new Error("Not in room");
+      });
+    });
+
     it("broadcasts to multiple rooms at a time", (done) => {
       function test() {
         client2.emit("do broadcast");


### PR DESCRIPTION
This line in the README suggests that you should be able to use the server to send messages to all clients in a room. When I do that I end up with the stacktrace below error.
`io.to('room42').emit('hello', "to all clients in 'room42' room");`

Not sure if I have understood how to use the server/namespace correctly, but I found this bug in my app when I wanted to update to socketio v3. In my app I want the server to broadcast a message to a specific room and that triggers the following stacktrace. 
```
TypeError: opts.except is not iterable
  at RedisAdapter.broadcast (/usr/src/node_modules/socket.io-redis/dist/index.js:255:34)
  at Namespace.emit (/usr/src/node_modules/socket.io/dist/namespace.js:175:22)
  at Server.<computed> [as emit] (/usr/src/node_modules/socket.io/dist/index.js:442:33)
  at /usr/src/services/websocket-handler-service/src/events/rooms.js:13:25
  at /usr/src/packages/message-broker/index.js:28:5
  at Array.forEach (<anonymous>)
  at Redis.<anonymous> (/usr/src/packages/message-broker/index.js:27:22)
  at Redis.emit (events.js:315:20)
  at DataHandler.handleSubscriberReply (/usr/src/node_modules/ioredis/built/DataHandler.js:80:32)
  at DataHandler.returnReply (/usr/src/node_modules/ioredis/built/DataHandler.js:47:18)
```

Please either merge this PR or explain to me how I'm supposed to broadcast a message to a specific room. (tried to do it with `client.broadcast.to(roomId)`, but that doesn't actually send it to everyone in the room. My guess is that it's because the client doesn't actually know what sockets are in the specified room.